### PR TITLE
Release / 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.0.9 (May 19, 2025)
+
+### Public Beta release
+- Starting from this version, the beta (snapshot) dependency package has been replaced with the public dependency package
+- Intended for early access and feedback

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/sendbird/sendbird-ai-agent-core-ios",
-            branch: "release/0.0.7"
+            from: "0.0.9"
         )
     ],
     targets: [


### PR DESCRIPTION
# Changelog

## v0.0.9 (May 19, 2025)

### Public Beta release
- Starting from this version, the beta (snapshot) dependency package has been replaced with the public dependency package
- Intended for early access and feedback
